### PR TITLE
Fix indentation in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,30 +73,30 @@ ui-build-serverside:
 export COMPONENT_INDEX
 export COMPONENT_VIEW
 create-component:
-  define COMPONENT_INDEX
-import view from './view'
-import state from './state'
-import * as reducers from './reducers'
-import * as effects from './effects'
+	define COMPONENT_INDEX
+		import view from './view'
+		import state from './state'
+		import * as reducers from './reducers'
+		import * as effects from './effects'
 
-export default {
-  namespace: '$(name)',
-  view,
-  state,
-  reducers,
-	effects
-}
-  endef
+	export default {
+		namespace: '$(name)',
+		view,
+		state,
+		reducers,
+		effects
+	}
+	endef
 
-define COMPONENT_VIEW
-import html from "choo/html"
+	define COMPONENT_VIEW
+		import html from "choo/html"
 
-const view = (state, prev, send) => html`
-$(name)
-`
+		const view = (state, prev, send) => html`
+			$(name)
+		`
 
-export default view
-  endef
+		export default view
+	endef
 
 	@mkdir ui/components/${name}
 	@echo "$$COMPONENT_INDEX" > ui/components/${name}/index.js


### PR DESCRIPTION
I do not know if this is a Mac / Linux thing, but when trying to run the commands defined in the Makefile on Ubuntu 16.04 I will get

```
Makefile:101: *** Recipe commences before first target. Stop.
```

where my make version is

```
frederik@xps[go-choo-starter](master) $ make -v
GNU Make 4.1
Gebaut für x86_64-pc-linux-gnu
Copyright (C) 1988-2014 Free Software Foundation, Inc.
Lizenz GPLv3+: GNU GPL Version 3 oder später <http://gnu.org/licenses/gpl.html>
Dies ist freie Software: Sie können sie nach Belieben ändern und weiter verteilen.
Soweit es die Gesetze erlauben gibt es KEINE GARANTIE.
```

I think this is due to the mix of spaces and tabs in indentation as changing it as seen in this PR fixes things for me.

Then it will probably mess with the prevailing indent style in all the JavaScript, so I do not know if there is a better solution to this.


